### PR TITLE
Utilisation vscode devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"matangover.mypy",
+				"ms-python.python",
+				"ms-python.pylint",
+				"ms-toolsai.jupyter",
+				"charliermarsh.ruff"
+			]
+		}
+	},
+
+	// for python graphic output
+	"containerEnv": {
+		"QT_QPA_PLATFORM": "offscreen"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	//"postCreateCommand": "pip3 install --user -r requirements.txt"
+	"postCreateCommand": "sudo apt update && sudo apt install -y graphviz && pip install --user -r requirements.txt && python3 -m venv .venv --system-site-packages",
+    "features": {
+   		  "ghcr.io/devcontainers/features/nvidia-cuda": {
+			"installCudnn": true,
+			"installNvtx": false,
+			"installToolkit": false,
+			"cudaVersion": "12.8",
+			"cudnnVersion": "automatic"
+		},
+		"docker-in-docker": {
+            "version": "latest",
+            "moby": true,
+            "dockerDashComposeVersion": "v1"
+         }
+	},
+	"hostRequirements": {
+       "gpu":true
+    }
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 .vscode/
 .idea/
 *.log
+.venv/


### PR DESCRIPTION
Configuration pour utiliser l'extension devcontainer de vscode pour développer à l'intérieur d'un Docker.
Usage complètement facultatif.